### PR TITLE
RunTests.sh - prevent errors with folders' name with spaces

### DIFF
--- a/Scripts/RunTests.sh
+++ b/Scripts/RunTests.sh
@@ -38,10 +38,10 @@ if [ ! -e "$TEST_TARGET_EXECUTABLE_PATH" ]; then
   exit 1
 fi
 
-RUN_CMD="$TEST_TARGET_EXECUTABLE_PATH -RegisterForSystemEvents"
+RUN_CMD="\"$TEST_TARGET_EXECUTABLE_PATH\" -RegisterForSystemEvents"
 
 echo "Running: $RUN_CMD"
-$RUN_CMD
+eval $RUN_CMD
 RETVAL=$?
 
 unset DYLD_ROOT_PATH


### PR DESCRIPTION
Adding quotes around $TEST_TARGET_EXECUTABLE_PATH and running command with "eval" in RunTests.sh script to prevent errors with folders' name with spaces.

I found this issue when using this script to run tests within Jenkins Continuous Integration tool.
