### PR TITLE
Fix UI Tests When Running From Command Line

### DIFF
--- a/Classes-IPhone/GHUnitIPhoneAppDelegate.m
+++ b/Classes-IPhone/GHUnitIPhoneAppDelegate.m
@@ -33,6 +33,15 @@
 @implementation GHUnitIPhoneAppDelegate
 
 - (void)applicationDidFinishLaunching:(UIApplication *)application {
+  if (getenv("GHUNIT_CLI")) {
+    int exitStatus = [GHTestRunner run];
+    if ([application respondsToSelector:@selector(_terminateWithStatus:)]) {
+      [application performSelector:@selector(_terminateWithStatus:)
+                        withObject:(id)exitStatus];
+    } else {
+      exit(exitStatus);
+    }
+  }
   GHUnitIPhoneViewController *viewController = [[GHUnitIPhoneViewController alloc] init];   
   [viewController loadDefaults];
   navigationController_ = [[UINavigationController alloc] initWithRootViewController:viewController];

--- a/Project-IPhone/GHUnitIOSTestMain.m
+++ b/Project-IPhone/GHUnitIOSTestMain.m
@@ -69,14 +69,8 @@ int main(int argc, char *argv[]) {
   // Register any special test case classes
   //[[GHTesting sharedInstance] registerClassName:@"GHSpecialTestCase"];  
   
-  int retVal = 0;
-  // If GHUNIT_CLI is set we are using the command line interface and run the tests
-  // Otherwise load the GUI app
-  if (getenv("GHUNIT_CLI")) {
-    retVal = [GHTestRunner run];
-  } else {
-    retVal = UIApplicationMain(argc, argv, nil, @"GHUnitIPhoneAppDelegate");
-  }
+  int retVal = UIApplicationMain(argc, argv, nil, @"GHUnitIPhoneAppDelegate");
+
   [pool release];
   return retVal;
 }


### PR DESCRIPTION
Run tests, even on CLI, inside UIApplicationMain, so instantiating views using fonts (like UILabel etc) in tests doesn't crash.
