### PR TITLE
To "right-click" in the project pane, use Control-Click, not Command-Click

### DIFF
--- a/_installing.html
+++ b/_installing.html
@@ -77,7 +77,7 @@ Create a Test Target</h3>
 <h3><a class="anchor" id="ConfigureTestTargetXcode4"></a>
 Configure the Test Target</h3>
 <ul>
-<li>Download and copy the GHUnitIOS.framework to your project. Command click on Frameworks in the Project Navigator and select: Add Files to "MyTestable"...</li>
+<li>Download and copy the GHUnitIOS.framework to your project. Control click on Frameworks in the Project Navigator and select: Add Files to "MyTestable"...</li>
 </ul>
 <div align="center">
 <img src="http://rel.me.s3.amazonaws.com/gh-unit/images/Installing/6_add_framework.png" alt="6_add_framework.png"/>
@@ -133,7 +133,7 @@ Configure the Test Target</h3>
 <h3><a class="anchor" id="CreateTestXcode4"></a>
 Create a Test</h3>
 <ul>
-<li>Command click on the Tests folder and select: New File...</li>
+<li>Control click on the Tests folder and select: New File...</li>
 <li>Under iOS, Cocoa Touch, select Objective-C class and select Next. Leave the default subclass and select Next again.</li>
 <li>Name the file MyTest.m and make sure its enabled only for the "Tests" target.</li>
 <li>Delete the MyTest.h file and replace the MyTest.m file with:</li>


### PR DESCRIPTION
To "right-click" in the project pane, use Control-Click, not Command-Click
