### PR TITLE
Fix misplaced apostrophe

### DIFF
--- a/_command_line.html
+++ b/_command_line.html
@@ -85,7 +85,7 @@ Command Line Environment</h3>
 <h2><a class="anchor" id="Makefile"></a>
 Makefile</h2>
 <p>Follow the directions above for adding command line support.</p>
-<p>Example Makefile's for Mac or iPhone apps:</p>
+<p>Example Makefiles for Mac or iPhone apps:</p>
 <ul>
 <li>Makefile (Mac OS X): <a href="http://github.com/gabriel/gh-unit/tree/master/Project/Makefile.example">http://github.com/gabriel/gh-unit/tree/master/Project/Makefile.example</a> (for a Mac App)</li>
 <li>Makefile (iOS): <a href="http://github.com/gabriel/gh-unit/tree/master/Project-iOS/Makefile.example">http://github.com/gabriel/gh-unit/tree/master/Project-iOS/Makefile.example</a> (for an iOS App)</li>


### PR DESCRIPTION
No ' needed when pluralizing "Makefile"
