### PR TITLE
compare the number of disabled tests to the total number of tests

### DIFF
--- a/Classes/GHTest/GHTest.h
+++ b/Classes/GHTest/GHTest.h
@@ -166,6 +166,11 @@ extern NSString *NSStringFromGHTestStats(GHTestStats stats);
  */
 - (NSInteger)disabledCount;
 
+/*!
+ @result The number of tests
+ */
+- (NSInteger)testCount;
+
 @end
 
 /*!

--- a/Classes/GHTest/GHTest.m
+++ b/Classes/GHTest/GHTest.m
@@ -168,6 +168,10 @@ exception=exception_, status=status_, log=log_, identifier=identifier_, disabled
   return (disabled_ || hidden_ ? 1 : 0);
 }
 
+- (NSInteger)testCount {
+  return 1;
+}
+
 - (void)setException:(NSException *)exception {
   [exception retain];
   [exception_ release];

--- a/Classes/GHTest/GHTestGroup.m
+++ b/Classes/GHTest/GHTestGroup.m
@@ -218,6 +218,14 @@ status=status_, testCase=testCase_, exception=exception_, options=options_;
   return disabledCount;
 }
 
+- (NSInteger)testCount {
+  NSInteger testCount = 0;
+  for(id<GHTest> test in children_) {
+    testCount += [test testCount];
+  }
+  return testCount;
+}
+
 - (void)setUpClass {
   if (didSetUpClass_) return;
   didSetUpClass_ = YES;
@@ -262,7 +270,7 @@ status=status_, testCase=testCase_, exception=exception_, options=options_;
 }
 
 - (BOOL)hasEnabledChildren {
-  return (([children_ count] - [self disabledCount]) <= 0);
+  return (([self testCount] - [self disabledCount]) <= 0);
 }
 
 - (void)_run:(NSOperationQueue *)operationQueue {


### PR DESCRIPTION
Previously, `GHTestGroup` would compare the number of `children_` to the number of disabled test methods to see if there were any to run.

But in the top level `GHTestGroup` object, `children_` is a collection of test classes, not test methods, so the comparison didn't seem right. I'm now comparing the number of disabled test methods to the total number of test methods - and my freezing problem has gone away.

(See issue 46 for more details. In my particular case, I had several test classes - some of which were just base classes for common functionality, so didn't contain any test methods themselves - and the application appeared to freeze if I chose to run just one test method. May be because the number of test classes was greater than the total number of test methods in those classes.)
