### PR TITLE
Run $IPHONE_SIMULATOR_ROOT/libexec/securityd during tests

### DIFF
--- a/Scripts/RunIPhoneSecurityd.sh
+++ b/Scripts/RunIPhoneSecurityd.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+set -u
+
+export DYLD_ROOT_PATH="$1"
+export IPHONE_SIMULATOR_ROOT="$1"
+export CFFIXED_USER_HOME="$2"
+
+"$IPHONE_SIMULATOR_ROOT"/usr/libexec/securityd

--- a/Scripts/RunTests.sh
+++ b/Scripts/RunTests.sh
@@ -14,7 +14,7 @@ export CFFIXED_USER_HOME="$TEMP_FILES_DIR/iPhone Simulator User Dir" # Be compat
 if [ -d $"CFFIXED_USER_HOME" ]; then
   rm -rf "$CFFIXED_USER_HOME"
 fi
-mkdir "$CFFIXED_USER_HOME"
+mkdir -p "$CFFIXED_USER_HOME"
 
 export NSDebugEnabled=YES
 export NSZombieEnabled=YES
@@ -36,6 +36,12 @@ if [ ! -e "$TEST_TARGET_EXECUTABLE_PATH" ]; then
   echo ""
   exit 1
 fi
+
+# If trapping fails, make sure we kill any running securityd
+launchctl list | grep GHUNIT_RunIPhoneSecurityd && launchctl remove GHUNIT_RunIPhoneSecurityd
+SCRIPTS_PATH=`cd $(dirname $0); pwd`
+launchctl submit -l GHUNIT_RunIPhoneSecurityd -- "$SCRIPTS_PATH"/RunIPhoneSecurityd.sh $IPHONE_SIMULATOR_ROOT $CFFIXED_USER_HOME
+trap "launchctl remove GHUNIT_RunIPhoneSecurityd" EXIT TERM INT
 
 RUN_CMD="\"$TEST_TARGET_EXECUTABLE_PATH\" -RegisterForSystemEvents"
 


### PR DESCRIPTION
For tests that use the keychain to work from the command line, $IPHONE_SIMULATOR_ROOT/libexec/securityd must be running. I ran securityd using a launchd task so I could kill it easily without interfering with the host system securityd.
