### PR TITLE
When building a static lib, copy public headers.

### DIFF
--- a/Project-iOS/GHUnitIOS.xcodeproj/project.pbxproj
+++ b/Project-iOS/GHUnitIOS.xcodeproj/project.pbxproj
@@ -22,96 +22,96 @@
 /* Begin PBXBuildFile section */
 		0012D1EC140EFD960093EC59 /* libGHUnitIOSSimulator.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0041C5EA13BA7B8A0015FC22 /* libGHUnitIOSSimulator.a */; };
 		0041C5EE13BA7B8A0015FC22 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0041C5ED13BA7B8A0015FC22 /* Foundation.framework */; };
-		0041C65613BA7C9A0015FC22 /* GHAsyncTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62113BA7C9A0015FC22 /* GHAsyncTestCase.h */; };
-		0041C65713BA7C9A0015FC22 /* GHAsyncTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62113BA7C9A0015FC22 /* GHAsyncTestCase.h */; };
+		0041C65613BA7C9A0015FC22 /* GHAsyncTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62113BA7C9A0015FC22 /* GHAsyncTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C65713BA7C9A0015FC22 /* GHAsyncTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62113BA7C9A0015FC22 /* GHAsyncTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C65813BA7C9A0015FC22 /* GHAsyncTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62213BA7C9A0015FC22 /* GHAsyncTestCase.m */; };
 		0041C65913BA7C9A0015FC22 /* GHAsyncTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62213BA7C9A0015FC22 /* GHAsyncTestCase.m */; };
-		0041C65A13BA7C9A0015FC22 /* GHTest+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62413BA7C9A0015FC22 /* GHTest+JUnitXML.h */; };
-		0041C65B13BA7C9A0015FC22 /* GHTest+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62413BA7C9A0015FC22 /* GHTest+JUnitXML.h */; };
+		0041C65A13BA7C9A0015FC22 /* GHTest+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62413BA7C9A0015FC22 /* GHTest+JUnitXML.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C65B13BA7C9A0015FC22 /* GHTest+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62413BA7C9A0015FC22 /* GHTest+JUnitXML.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C65C13BA7C9A0015FC22 /* GHTest+JUnitXML.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62513BA7C9A0015FC22 /* GHTest+JUnitXML.m */; };
 		0041C65D13BA7C9A0015FC22 /* GHTest+JUnitXML.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62513BA7C9A0015FC22 /* GHTest+JUnitXML.m */; };
-		0041C65E13BA7C9A0015FC22 /* GHTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62613BA7C9A0015FC22 /* GHTest.h */; };
-		0041C65F13BA7C9A0015FC22 /* GHTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62613BA7C9A0015FC22 /* GHTest.h */; };
+		0041C65E13BA7C9A0015FC22 /* GHTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62613BA7C9A0015FC22 /* GHTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C65F13BA7C9A0015FC22 /* GHTest.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62613BA7C9A0015FC22 /* GHTest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C66013BA7C9A0015FC22 /* GHTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62713BA7C9A0015FC22 /* GHTest.m */; };
 		0041C66113BA7C9A0015FC22 /* GHTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62713BA7C9A0015FC22 /* GHTest.m */; };
-		0041C66213BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62813BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h */; };
-		0041C66313BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62813BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h */; };
+		0041C66213BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62813BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C66313BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62813BA7C9A0015FC22 /* GHTestGroup+JUnitXML.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C66413BA7C9A0015FC22 /* GHTestGroup+JUnitXML.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62913BA7C9A0015FC22 /* GHTestGroup+JUnitXML.m */; };
 		0041C66513BA7C9A0015FC22 /* GHTestGroup+JUnitXML.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62913BA7C9A0015FC22 /* GHTestGroup+JUnitXML.m */; };
-		0041C66613BA7C9A0015FC22 /* GHTestGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62A13BA7C9A0015FC22 /* GHTestGroup.h */; };
-		0041C66713BA7C9A0015FC22 /* GHTestGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62A13BA7C9A0015FC22 /* GHTestGroup.h */; };
+		0041C66613BA7C9A0015FC22 /* GHTestGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62A13BA7C9A0015FC22 /* GHTestGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C66713BA7C9A0015FC22 /* GHTestGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62A13BA7C9A0015FC22 /* GHTestGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C66813BA7C9A0015FC22 /* GHTestGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62B13BA7C9A0015FC22 /* GHTestGroup.m */; };
 		0041C66913BA7C9A0015FC22 /* GHTestGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62B13BA7C9A0015FC22 /* GHTestGroup.m */; };
-		0041C66A13BA7C9A0015FC22 /* GHTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62C13BA7C9A0015FC22 /* GHTesting.h */; };
-		0041C66B13BA7C9A0015FC22 /* GHTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62C13BA7C9A0015FC22 /* GHTesting.h */; };
+		0041C66A13BA7C9A0015FC22 /* GHTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62C13BA7C9A0015FC22 /* GHTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C66B13BA7C9A0015FC22 /* GHTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62C13BA7C9A0015FC22 /* GHTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C66C13BA7C9A0015FC22 /* GHTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62D13BA7C9A0015FC22 /* GHTesting.m */; };
 		0041C66D13BA7C9A0015FC22 /* GHTesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62D13BA7C9A0015FC22 /* GHTesting.m */; };
-		0041C66E13BA7C9A0015FC22 /* GHTestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62E13BA7C9A0015FC22 /* GHTestOperation.h */; };
-		0041C66F13BA7C9A0015FC22 /* GHTestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62E13BA7C9A0015FC22 /* GHTestOperation.h */; };
+		0041C66E13BA7C9A0015FC22 /* GHTestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62E13BA7C9A0015FC22 /* GHTestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C66F13BA7C9A0015FC22 /* GHTestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C62E13BA7C9A0015FC22 /* GHTestOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C67013BA7C9A0015FC22 /* GHTestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62F13BA7C9A0015FC22 /* GHTestOperation.m */; };
 		0041C67113BA7C9A0015FC22 /* GHTestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C62F13BA7C9A0015FC22 /* GHTestOperation.m */; };
-		0041C67213BA7C9A0015FC22 /* GHTestRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63013BA7C9A0015FC22 /* GHTestRunner.h */; };
-		0041C67313BA7C9A0015FC22 /* GHTestRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63013BA7C9A0015FC22 /* GHTestRunner.h */; };
+		0041C67213BA7C9A0015FC22 /* GHTestRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63013BA7C9A0015FC22 /* GHTestRunner.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C67313BA7C9A0015FC22 /* GHTestRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63013BA7C9A0015FC22 /* GHTestRunner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C67413BA7C9A0015FC22 /* GHTestRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63113BA7C9A0015FC22 /* GHTestRunner.m */; };
 		0041C67513BA7C9A0015FC22 /* GHTestRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63113BA7C9A0015FC22 /* GHTestRunner.m */; };
-		0041C67613BA7C9A0015FC22 /* GHTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63213BA7C9A0015FC22 /* GHTestSuite.h */; };
-		0041C67713BA7C9A0015FC22 /* GHTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63213BA7C9A0015FC22 /* GHTestSuite.h */; };
+		0041C67613BA7C9A0015FC22 /* GHTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63213BA7C9A0015FC22 /* GHTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C67713BA7C9A0015FC22 /* GHTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63213BA7C9A0015FC22 /* GHTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C67813BA7C9A0015FC22 /* GHTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63313BA7C9A0015FC22 /* GHTestSuite.m */; };
 		0041C67913BA7C9A0015FC22 /* GHTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63313BA7C9A0015FC22 /* GHTestSuite.m */; };
-		0041C67A13BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63413BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h */; };
-		0041C67B13BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63413BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h */; };
+		0041C67A13BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63413BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C67B13BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63413BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C67C13BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63513BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.m */; };
 		0041C67D13BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63513BA7C9A0015FC22 /* NSException+GHTestFailureExceptions.m */; };
-		0041C67E13BA7C9A0015FC22 /* NSValue+GHValueFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63613BA7C9A0015FC22 /* NSValue+GHValueFormatter.h */; };
-		0041C67F13BA7C9A0015FC22 /* NSValue+GHValueFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63613BA7C9A0015FC22 /* NSValue+GHValueFormatter.h */; };
+		0041C67E13BA7C9A0015FC22 /* NSValue+GHValueFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63613BA7C9A0015FC22 /* NSValue+GHValueFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C67F13BA7C9A0015FC22 /* NSValue+GHValueFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63613BA7C9A0015FC22 /* NSValue+GHValueFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C68013BA7C9A0015FC22 /* NSValue+GHValueFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63713BA7C9A0015FC22 /* NSValue+GHValueFormatter.m */; };
 		0041C68113BA7C9A0015FC22 /* NSValue+GHValueFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63713BA7C9A0015FC22 /* NSValue+GHValueFormatter.m */; };
-		0041C68213BA7C9A0015FC22 /* GHTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63813BA7C9A0015FC22 /* GHTestCase.h */; };
-		0041C68313BA7C9A0015FC22 /* GHTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63813BA7C9A0015FC22 /* GHTestCase.h */; };
+		0041C68213BA7C9A0015FC22 /* GHTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63813BA7C9A0015FC22 /* GHTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C68313BA7C9A0015FC22 /* GHTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63813BA7C9A0015FC22 /* GHTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C68413BA7C9A0015FC22 /* GHTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63913BA7C9A0015FC22 /* GHTestCase.m */; };
 		0041C68513BA7C9A0015FC22 /* GHTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63913BA7C9A0015FC22 /* GHTestCase.m */; };
-		0041C68613BA7C9A0015FC22 /* GHTestMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63A13BA7C9A0015FC22 /* GHTestMacros.h */; };
-		0041C68713BA7C9A0015FC22 /* GHTestMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63A13BA7C9A0015FC22 /* GHTestMacros.h */; };
-		0041C68813BA7C9A0015FC22 /* GHUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63B13BA7C9A0015FC22 /* GHUnit.h */; };
-		0041C68913BA7C9A0015FC22 /* GHUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63B13BA7C9A0015FC22 /* GHUnit.h */; };
-		0041C68A13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63D13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h */; };
-		0041C68B13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63D13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h */; };
+		0041C68613BA7C9A0015FC22 /* GHTestMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63A13BA7C9A0015FC22 /* GHTestMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C68713BA7C9A0015FC22 /* GHTestMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63A13BA7C9A0015FC22 /* GHTestMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C68813BA7C9A0015FC22 /* GHUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63B13BA7C9A0015FC22 /* GHUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C68913BA7C9A0015FC22 /* GHUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63B13BA7C9A0015FC22 /* GHUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C68A13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63D13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C68B13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63D13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C68C13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63E13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.m */; };
 		0041C68D13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C63E13BA7C9A0015FC22 /* GHMockNSHTTPURLResponse.m */; };
-		0041C68E13BA7C9A0015FC22 /* GHMockNSURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63F13BA7C9A0015FC22 /* GHMockNSURLConnection.h */; };
-		0041C68F13BA7C9A0015FC22 /* GHMockNSURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63F13BA7C9A0015FC22 /* GHMockNSURLConnection.h */; };
+		0041C68E13BA7C9A0015FC22 /* GHMockNSURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63F13BA7C9A0015FC22 /* GHMockNSURLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C68F13BA7C9A0015FC22 /* GHMockNSURLConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C63F13BA7C9A0015FC22 /* GHMockNSURLConnection.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C69013BA7C9A0015FC22 /* GHMockNSURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64013BA7C9A0015FC22 /* GHMockNSURLConnection.m */; };
 		0041C69113BA7C9A0015FC22 /* GHMockNSURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64013BA7C9A0015FC22 /* GHMockNSURLConnection.m */; };
-		0041C69213BA7C9A0015FC22 /* GHNSLocale+Mock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64113BA7C9A0015FC22 /* GHNSLocale+Mock.h */; };
-		0041C69313BA7C9A0015FC22 /* GHNSLocale+Mock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64113BA7C9A0015FC22 /* GHNSLocale+Mock.h */; };
+		0041C69213BA7C9A0015FC22 /* GHNSLocale+Mock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64113BA7C9A0015FC22 /* GHNSLocale+Mock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C69313BA7C9A0015FC22 /* GHNSLocale+Mock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64113BA7C9A0015FC22 /* GHNSLocale+Mock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C69413BA7C9A0015FC22 /* GHNSLocale+Mock.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64213BA7C9A0015FC22 /* GHNSLocale+Mock.m */; };
 		0041C69513BA7C9A0015FC22 /* GHNSLocale+Mock.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64213BA7C9A0015FC22 /* GHNSLocale+Mock.m */; };
-		0041C69613BA7C9A0015FC22 /* GHUNSObject+Swizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64313BA7C9A0015FC22 /* GHUNSObject+Swizzle.h */; };
-		0041C69713BA7C9A0015FC22 /* GHUNSObject+Swizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64313BA7C9A0015FC22 /* GHUNSObject+Swizzle.h */; };
+		0041C69613BA7C9A0015FC22 /* GHUNSObject+Swizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64313BA7C9A0015FC22 /* GHUNSObject+Swizzle.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C69713BA7C9A0015FC22 /* GHUNSObject+Swizzle.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64313BA7C9A0015FC22 /* GHUNSObject+Swizzle.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C69813BA7C9A0015FC22 /* GHUNSObject+Swizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64413BA7C9A0015FC22 /* GHUNSObject+Swizzle.m */; };
 		0041C69913BA7C9A0015FC22 /* GHUNSObject+Swizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64413BA7C9A0015FC22 /* GHUNSObject+Swizzle.m */; };
-		0041C69A13BA7C9A0015FC22 /* GHTestViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64613BA7C9A0015FC22 /* GHTestViewModel.h */; };
-		0041C69B13BA7C9A0015FC22 /* GHTestViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64613BA7C9A0015FC22 /* GHTestViewModel.h */; };
+		0041C69A13BA7C9A0015FC22 /* GHTestViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64613BA7C9A0015FC22 /* GHTestViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C69B13BA7C9A0015FC22 /* GHTestViewModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64613BA7C9A0015FC22 /* GHTestViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C69C13BA7C9A0015FC22 /* GHTestViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64713BA7C9A0015FC22 /* GHTestViewModel.m */; };
 		0041C69D13BA7C9A0015FC22 /* GHTestViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64713BA7C9A0015FC22 /* GHTestViewModel.m */; };
-		0041C69E13BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64913BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h */; };
-		0041C69F13BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64913BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h */; };
+		0041C69E13BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64913BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C69F13BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64913BA7C9A0015FC22 /* GHUnitIOSAppDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C6A013BA7C9A0015FC22 /* GHUnitIOSAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64A13BA7C9A0015FC22 /* GHUnitIOSAppDelegate.m */; };
 		0041C6A113BA7C9A0015FC22 /* GHUnitIOSAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64A13BA7C9A0015FC22 /* GHUnitIOSAppDelegate.m */; };
-		0041C6A213BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64B13BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h */; };
-		0041C6A313BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64B13BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h */; };
+		0041C6A213BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64B13BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C6A313BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64B13BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C6A413BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64C13BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.m */; };
 		0041C6A513BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64C13BA7C9A0015FC22 /* GHUnitIOSTableViewDataSource.m */; };
-		0041C6A613BA7C9A0015FC22 /* GHUnitIOSTestViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64D13BA7C9A0015FC22 /* GHUnitIOSTestViewController.h */; };
-		0041C6A713BA7C9A0015FC22 /* GHUnitIOSTestViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64D13BA7C9A0015FC22 /* GHUnitIOSTestViewController.h */; };
+		0041C6A613BA7C9A0015FC22 /* GHUnitIOSTestViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64D13BA7C9A0015FC22 /* GHUnitIOSTestViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C6A713BA7C9A0015FC22 /* GHUnitIOSTestViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64D13BA7C9A0015FC22 /* GHUnitIOSTestViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C6A813BA7C9A0015FC22 /* GHUnitIOSTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64E13BA7C9A0015FC22 /* GHUnitIOSTestViewController.m */; };
 		0041C6A913BA7C9A0015FC22 /* GHUnitIOSTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C64E13BA7C9A0015FC22 /* GHUnitIOSTestViewController.m */; };
-		0041C6AA13BA7C9A0015FC22 /* GHUnitIOSView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64F13BA7C9A0015FC22 /* GHUnitIOSView.h */; };
-		0041C6AB13BA7C9A0015FC22 /* GHUnitIOSView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64F13BA7C9A0015FC22 /* GHUnitIOSView.h */; };
+		0041C6AA13BA7C9A0015FC22 /* GHUnitIOSView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64F13BA7C9A0015FC22 /* GHUnitIOSView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C6AB13BA7C9A0015FC22 /* GHUnitIOSView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C64F13BA7C9A0015FC22 /* GHUnitIOSView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C6AC13BA7C9A0015FC22 /* GHUnitIOSView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C65013BA7C9A0015FC22 /* GHUnitIOSView.m */; };
 		0041C6AD13BA7C9A0015FC22 /* GHUnitIOSView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C65013BA7C9A0015FC22 /* GHUnitIOSView.m */; };
-		0041C6AE13BA7C9A0015FC22 /* GHUnitIOSViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C65113BA7C9A0015FC22 /* GHUnitIOSViewController.h */; };
-		0041C6AF13BA7C9A0015FC22 /* GHUnitIOSViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C65113BA7C9A0015FC22 /* GHUnitIOSViewController.h */; };
+		0041C6AE13BA7C9A0015FC22 /* GHUnitIOSViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C65113BA7C9A0015FC22 /* GHUnitIOSViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0041C6AF13BA7C9A0015FC22 /* GHUnitIOSViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0041C65113BA7C9A0015FC22 /* GHUnitIOSViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0041C6B013BA7C9A0015FC22 /* GHUnitIOSViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C65213BA7C9A0015FC22 /* GHUnitIOSViewController.m */; };
 		0041C6B113BA7C9A0015FC22 /* GHUnitIOSViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0041C65213BA7C9A0015FC22 /* GHUnitIOSViewController.m */; };
 		0066A0BD13C51359006B7022 /* GTMGarbageCollection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0066A0BA13C51359006B7022 /* GTMGarbageCollection.h */; };
@@ -120,7 +120,7 @@
 		0066A0C013C51359006B7022 /* GTMNSString+XML.h in Headers */ = {isa = PBXBuildFile; fileRef = 0066A0BB13C51359006B7022 /* GTMNSString+XML.h */; };
 		0066A0C113C51359006B7022 /* GTMNSString+XML.m in Sources */ = {isa = PBXBuildFile; fileRef = 0066A0BC13C51359006B7022 /* GTMNSString+XML.m */; };
 		0066A0C213C51359006B7022 /* GTMNSString+XML.m in Sources */ = {isa = PBXBuildFile; fileRef = 0066A0BC13C51359006B7022 /* GTMNSString+XML.m */; };
-		0088BC9413F4C19E0084C69E /* GHUnitIPhoneAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 00C979CD13BA8A5000FC285C /* GHUnitIPhoneAppDelegate.h */; };
+		0088BC9413F4C19E0084C69E /* GHUnitIPhoneAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 00C979CD13BA8A5000FC285C /* GHUnitIPhoneAppDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0097C45B13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097C44C13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.h */; };
 		0097C45C13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 0097C44C13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.h */; };
 		0097C45D13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.m in Sources */ = {isa = PBXBuildFile; fileRef = 0097C44D13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.m */; };
@@ -166,22 +166,22 @@
 		00C979A113BA809600FC285C /* GHTestOnMainThread.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C9798C13BA809600FC285C /* GHTestOnMainThread.m */; };
 		00C979A213BA809600FC285C /* GHUnitIOSTestMain.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C9798D13BA809600FC285C /* GHUnitIOSTestMain.m */; };
 		00C979A313BA809600FC285C /* GTMSenTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C9799013BA809600FC285C /* GTMSenTestCase.m */; };
-		00C979CF13BA8A5100FC285C /* GHUnitIPhoneAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 00C979CD13BA8A5000FC285C /* GHUnitIPhoneAppDelegate.h */; };
+		00C979CF13BA8A5100FC285C /* GHUnitIPhoneAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 00C979CD13BA8A5000FC285C /* GHUnitIPhoneAppDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00C979D013BA8A5100FC285C /* GHUnitIPhoneAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C979CE13BA8A5000FC285C /* GHUnitIPhoneAppDelegate.m */; };
-		421C7B8F13F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */ = {isa = PBXBuildFile; fileRef = 421C7B8D13F0AF1D00E21E74 /* GHUnitIOSTestView.h */; };
-		421C7B9013F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */ = {isa = PBXBuildFile; fileRef = 421C7B8D13F0AF1D00E21E74 /* GHUnitIOSTestView.h */; };
+		421C7B8F13F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */ = {isa = PBXBuildFile; fileRef = 421C7B8D13F0AF1D00E21E74 /* GHUnitIOSTestView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		421C7B9013F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */ = {isa = PBXBuildFile; fileRef = 421C7B8D13F0AF1D00E21E74 /* GHUnitIOSTestView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		421C7B9113F0AF1D00E21E74 /* GHUnitIOSTestView.m in Sources */ = {isa = PBXBuildFile; fileRef = 421C7B8E13F0AF1D00E21E74 /* GHUnitIOSTestView.m */; };
 		421C7B9213F0AF1D00E21E74 /* GHUnitIOSTestView.m in Sources */ = {isa = PBXBuildFile; fileRef = 421C7B8E13F0AF1D00E21E74 /* GHUnitIOSTestView.m */; };
-		422863111458BC1200BF3ED2 /* GHViewTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228630F1458BC1200BF3ED2 /* GHViewTestCase.h */; };
-		422863121458BC1200BF3ED2 /* GHViewTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228630F1458BC1200BF3ED2 /* GHViewTestCase.h */; };
+		422863111458BC1200BF3ED2 /* GHViewTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228630F1458BC1200BF3ED2 /* GHViewTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		422863121458BC1200BF3ED2 /* GHViewTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228630F1458BC1200BF3ED2 /* GHViewTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		422863131458BC1200BF3ED2 /* GHViewTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 422863101458BC1200BF3ED2 /* GHViewTestCase.m */; };
 		422863141458BC1200BF3ED2 /* GHViewTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 422863101458BC1200BF3ED2 /* GHViewTestCase.m */; };
-		4228635814595D0400BF3ED2 /* GHImageDiffView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228635614595D0400BF3ED2 /* GHImageDiffView.h */; };
+		4228635814595D0400BF3ED2 /* GHImageDiffView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228635614595D0400BF3ED2 /* GHImageDiffView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4228635914595D0400BF3ED2 /* GHImageDiffView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4228635714595D0400BF3ED2 /* GHImageDiffView.m */; };
 		423AF3341460962700F04DC7 /* YKUIImageViewControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 42A678FE1401509B0060D1B5 /* YKUIImageViewControl.m */; };
 		423AF3371460965C00F04DC7 /* GHImageDiffView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4228635714595D0400BF3ED2 /* GHImageDiffView.m */; };
 		423AF3381460968200F04DC7 /* GHUnitIPhoneAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 00C979CE13BA8A5000FC285C /* GHUnitIPhoneAppDelegate.m */; };
-		423AF3391460969000F04DC7 /* GHImageDiffView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228635614595D0400BF3ED2 /* GHImageDiffView.h */; };
+		423AF3391460969000F04DC7 /* GHImageDiffView.h in Headers */ = {isa = PBXBuildFile; fileRef = 4228635614595D0400BF3ED2 /* GHImageDiffView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		42A678EF1401423D0060D1B5 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42A678EE1401423D0060D1B5 /* QuartzCore.framework */; };
 		42A678FF1401509B0060D1B5 /* YKUIImageViewControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 42A678FD1401509B0060D1B5 /* YKUIImageViewControl.h */; };
 		42A679001401509B0060D1B5 /* YKUIImageViewControl.m in Sources */ = {isa = PBXBuildFile; fileRef = 42A678FE1401509B0060D1B5 /* YKUIImageViewControl.m */; };
@@ -671,19 +671,19 @@
 				0041C6A613BA7C9A0015FC22 /* GHUnitIOSTestViewController.h in Headers */,
 				0041C6AA13BA7C9A0015FC22 /* GHUnitIOSView.h in Headers */,
 				0041C6AE13BA7C9A0015FC22 /* GHUnitIOSViewController.h in Headers */,
+				00C979CF13BA8A5100FC285C /* GHUnitIPhoneAppDelegate.h in Headers */,
+				421C7B8F13F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */,
+				422863111458BC1200BF3ED2 /* GHViewTestCase.h in Headers */,
+				4228635814595D0400BF3ED2 /* GHImageDiffView.h in Headers */,
 				0097C45B13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.h in Headers */,
 				0097C45F13BA7EEC00D3BEF0 /* GHNSInvocationProxy.h in Headers */,
 				0097C46313BA7EEC00D3BEF0 /* GHNSObject+Invocation.h in Headers */,
 				0097C46713BA7EEC00D3BEF0 /* GTMObjC2Runtime.h in Headers */,
 				0097C46B13BA7EEC00D3BEF0 /* GTMStackTrace.h in Headers */,
 				0097C46F13BA7EEC00D3BEF0 /* GTMDefines.h in Headers */,
-				00C979CF13BA8A5100FC285C /* GHUnitIPhoneAppDelegate.h in Headers */,
 				0066A0BD13C51359006B7022 /* GTMGarbageCollection.h in Headers */,
 				0066A0BF13C51359006B7022 /* GTMNSString+XML.h in Headers */,
-				421C7B8F13F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */,
 				42A678FF1401509B0060D1B5 /* YKUIImageViewControl.h in Headers */,
-				422863111458BC1200BF3ED2 /* GHViewTestCase.h in Headers */,
-				4228635814595D0400BF3ED2 /* GHImageDiffView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -715,6 +715,10 @@
 				0041C6A713BA7C9A0015FC22 /* GHUnitIOSTestViewController.h in Headers */,
 				0041C6AB13BA7C9A0015FC22 /* GHUnitIOSView.h in Headers */,
 				0041C6AF13BA7C9A0015FC22 /* GHUnitIOSViewController.h in Headers */,
+				0088BC9413F4C19E0084C69E /* GHUnitIPhoneAppDelegate.h in Headers */,
+				421C7B9013F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */,
+				422863121458BC1200BF3ED2 /* GHViewTestCase.h in Headers */,
+				423AF3391460969000F04DC7 /* GHImageDiffView.h in Headers */,
 				0097C45C13BA7EEC00D3BEF0 /* GHNSInvocation+Utils.h in Headers */,
 				0097C46013BA7EEC00D3BEF0 /* GHNSInvocationProxy.h in Headers */,
 				0097C46413BA7EEC00D3BEF0 /* GHNSObject+Invocation.h in Headers */,
@@ -723,10 +727,6 @@
 				0097C47013BA7EEC00D3BEF0 /* GTMDefines.h in Headers */,
 				0066A0BE13C51359006B7022 /* GTMGarbageCollection.h in Headers */,
 				0066A0C013C51359006B7022 /* GTMNSString+XML.h in Headers */,
-				0088BC9413F4C19E0084C69E /* GHUnitIPhoneAppDelegate.h in Headers */,
-				421C7B9013F0AF1D00E21E74 /* GHUnitIOSTestView.h in Headers */,
-				422863121458BC1200BF3ED2 /* GHViewTestCase.h in Headers */,
-				423AF3391460969000F04DC7 /* GHImageDiffView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/XcodeConfig/Shared-iOS.xcconfig
+++ b/XcodeConfig/Shared-iOS.xcconfig
@@ -5,6 +5,9 @@ SDKROOT = iphoneos
 IPHONEOS_DEPLOYMENT_TARGET = 3.0
 //IPHONEOS_DEPLOYMENT_TARGET = 4.0
 
+PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/GHUnit
+PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/GHUnit
+
 // Testing with LLVM
 //GCC_VERSION = com.apple.compilers.llvm.clang.1_0
 


### PR DESCRIPTION
This way, people can consume GHUnit by just adding the Xcode project and linking with the static library.

I apologize for not responding on your last pull request. I will be more prompt in the future.
