### PR TITLE
memory leaks in GHTesting.m causing out-of-memory problems

### DIFF
--- a/Classes/GHTest/GHTesting.m
+++ b/Classes/GHTest/GHTesting.m
@@ -251,12 +251,14 @@ static GHTesting *gSharedInstance;
         if (strstr(name, "test") == name) {
           returnType = method_copyReturnType(currMethod);
           if (returnType) {
+            // @gabriel from jjm - this does not appear to work, i am seeing
+            //                     memory leaks on exceptions
             // This handles disposing of returnType for us even if an
             // exception should fly. Length +1 for the terminator, not that
             // the length really matters here, as we never reference inside
             // the data block.
-            [NSData dataWithBytes:returnType
-                                 length:strlen(returnType) + 1];
+            //[NSData dataWithBytes:returnType
+            //                     length:strlen(returnType) + 1];
           }
         }
         // TODO: If a test class is a subclass of another, and they reuse the
@@ -273,8 +275,10 @@ static GHTesting *gSharedInstance;
           [invocation setSelector:sel];
           [invocations addObject:invocation];
         }
+        if (returnType != NULL) free(returnType);
       }
     }
+    if (methods != NULL) free(methods);
   }
   // Match SenTestKit and run everything in alphbetical order.
   [invocations sortUsingFunction:MethodSort context:nil];

--- a/Scripts/RunTests.sh
+++ b/Scripts/RunTests.sh
@@ -8,12 +8,12 @@ fi
 export DYLD_ROOT_PATH="$SDKROOT"
 export DYLD_FRAMEWORK_PATH="$CONFIGURATION_BUILD_DIR"
 export IPHONE_SIMULATOR_ROOT="$SDKROOT"
-#export CFFIXED_USER_HOME="$TEMP_FILES_DIR/iPhone Simulator User Dir" # Be compatible with google-toolbox-for-mac
+export CFFIXED_USER_HOME="$TEMP_FILES_DIR/iPhone Simulator User Dir" # Be compatible with google-toolbox-for-mac
 
-#if [ -d $"CFFIXED_USER_HOME" ]; then
-#  rm -rf "$CFFIXED_USER_HOME"
-#fi
-#mkdir -p "$CFFIXED_USER_HOME"
+if [ -d $"CFFIXED_USER_HOME" ]; then
+  rm -rf "$CFFIXED_USER_HOME"
+fi
+mkdir -p "$CFFIXED_USER_HOME"
 
 export NSDebugEnabled=YES
 export NSZombieEnabled=YES


### PR DESCRIPTION
this commit fixes #93

fixes memory leaks in GHTesting and fixes RunTests.sh script so that 'make test' runs out of the box

GHTesting fixes two leaks by calling free:
- Method *methods = class_copyMethodList(currentClass, &methodCount);
- returnType = method_copyReturnType(currMethod);
- commented out a NSData dataWithBytes:returnType because it did not
  appear to be working as per the comment

RunTests.sh
see this discussion:
https://groups.google.com/d/topic/ghunit/35kF4hsqQWY/discussion
