### PR TITLE
Fix for size issue when showing results on iPad and background thread when re-running.

### DIFF
--- a/Classes-iOS/GHUnitIOSTestView.m
+++ b/Classes-iOS/GHUnitIOSTestView.m
@@ -37,8 +37,10 @@
 - (id)initWithFrame:(CGRect)frame {
   if ((self = [super initWithFrame:frame])) {
     self.backgroundColor = [UIColor whiteColor];
+	 self.contentMode = UIViewContentModeScaleToFill;
 
-    textLabel_ = [[UILabel alloc] initWithFrame:CGRectMake(10, 0, 300, 100)];
+    textLabel_ = [[UILabel alloc] initWithFrame:CGRectMake(10, 0, frame.size.width - 20, 100)];
+	 textLabel_.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     textLabel_.font = [UIFont systemFontOfSize:12];
     textLabel_.textColor = [UIColor blackColor];
     textLabel_.numberOfLines = 0;

--- a/Classes-iOS/GHUnitIOSTestViewController.m
+++ b/Classes-iOS/GHUnitIOSTestViewController.m
@@ -56,8 +56,10 @@
   id<GHTest> test = [testNode_.test copyWithZone:NULL];
   NSLog(@"Re-running: %@", test);
   [testView_ setText:@"Running..."];
-  [test run:GHTestOptionForceSetUpTearDownClass];  
-  [self setTest:test];
+	[self setTest:test];
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+		[test run:GHTestOptionForceSetUpTearDownClass];
+	});
 }
 
 - (void)_showImageDiff {


### PR DESCRIPTION
THis is a quick and dirty hack which fixes two issues:
1. When on an iPad the results view of a test is not sized to the iPad width.
2. When re-running a test from the result view of a test, the test is run on the main thread instead of the background thread.

Hope this helps.
