### PR TITLE
in MacOS project GHUnit.h incorrectly imports GHTestUtils

### DIFF
--- a/Classes/GHUnit.h
+++ b/Classes/GHUnit.h
@@ -32,18 +32,17 @@
 #import "GHTestSuite.h"
 #import "GHTestMacros.h"
 #import "GHTestRunner.h"
-
 #import "GHTest.h"
 #import "GHTesting.h"
 #import "GHTestOperation.h"
 #import "GHTestGroup.h"
 #import "GHTest+JUnitXML.h"
 #import "GHTestGroup+JUnitXML.h"
-#import "GHTestUtils.h"
 #import "NSException+GHTestFailureExceptions.h"
 #import "NSValue+GHValueFormatter.h"
 
 #if TARGET_OS_IPHONE
+#import "GHTestUtils.h"
 #import "GHUnitIOSAppDelegate.h"
 #import "GHViewTestCase.h"
 #endif


### PR DESCRIPTION
fixes issue #105

to reproduce the problem:
1. clone the latest gh-unit
2. cd gh-unit/Project-MacOSX
3. build the MacOS framework: eg.  CC=;make clean;make
4. create a new Xcode project that uses the GHUnit.framework you just
   created following these instructions:
   http://gabriel.github.com/gh-unit/docs/appledoc_include/guide_install_macosx_4.html
5. in Xcode, build and run

expected: no problems
found:
/Users/moody/git/gh-unit-fork/Test/Test/GHUnit.framework/Headers/GHUnit.h:42:9:
'GHTestUtils.h' file not found

solution:
1. in GHUnit.h move GHTestUtils.h to #if TARGET_OS_IPHONE block
2. repeat step 3 and replace GHUnit.framework in Xcode project
3. build

it is possible that GHTestUtils _should_ be part of the MacOS framework but i did not see the two functions defined there:

void GHRunForInterval(CFTimeInterval interval);
void GHRunUntilTimeoutWhileBlock(CFTimeInterval timeout, BOOL(^whileBlock)());

referenced in the MacOS project
