### PR TITLE
Fix performance hit due to reloading entire test table after each test

### DIFF
--- a/Classes/SharedUI/GHTestViewModel.m
+++ b/Classes/SharedUI/GHTestViewModel.m
@@ -40,8 +40,8 @@
 	if ((self = [super init])) {		
     identifier_ = identifier;
 		suite_ = suite;				
+		map_ = [NSMutableDictionary dictionary];
 		root_ = [[GHTestNode alloc] initWithTest:suite_ children:[suite_ children] source:self];
-		map_ = [NSMutableDictionary dictionary];		
 	}
 	return self;
 }


### PR DESCRIPTION
Our tests were failing on a low RAM virtual machine, because the main thread was dogged down doing a table reload data all the time.  The findTestNodeForTest function was always returning nil, which caused reloadItem to reload the entire table. Fixed findTestNodeForTest by fixing the initialization error in GFTestViewModel, so that the _map dictionary is not nil when building the test hierarchy.
