### PR TITLE
Workaround for expected build folder

### DIFF
--- a/Project-MacOSX/Makefile
+++ b/Project-MacOSX/Makefile
@@ -1,6 +1,6 @@
 
 default:
-	xcodebuild -target GHUnit -configuration Release -sdk macosx build && open build/Release
+	xcodebuild -target GHUnit -configuration Release -sdk macosx build SYMROOT=build && open build/Release
 
 # If you need to clean a specific target/configuration: $(COMMAND) -target $(TARGET) -configuration DebugOrRelease -sdk $(SDK) clean
 clean:

--- a/Project-iOS/Makefile
+++ b/Project-iOS/Makefile
@@ -1,7 +1,7 @@
 
 default:
-	xcodebuild -target "GHUnitIOS (Device)" -configuration Release
-	xcodebuild -target "GHUnitIOS (Simulator)" -configuration Release
+	xcodebuild -target "GHUnitIOS (Device)" -configuration Release SYMROOT=build
+	xcodebuild -target "GHUnitIOS (Simulator)" -configuration Release SYMROOT=build
 	BUILD_DIR="build" BUILD_STYLE="Release" sh ../Scripts/CombineLibs.sh
 	sh ../Scripts/iOSFramework.sh
 


### PR DESCRIPTION
The creation of frameworks failed for me, as xcodebuild uses a folder under ...DerivedData...
