### PR TITLE
Fix GHUnitIOSViewController is compilable when using iOS6 as a base SDK

### DIFF
--- a/Classes-iOS/GHUnitIOSViewController.m
+++ b/Classes-iOS/GHUnitIOSViewController.m
@@ -46,8 +46,10 @@ NSString *const GHUnitFilterKey = @"Filter";
 - (id)init {
   if ((self = [super init])) {
     self.title = @"Tests";
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000
     if ([self respondsToSelector:@selector(edgesForExtendedLayout)])
       self.edgesForExtendedLayout = UIRectEdgeNone;
+#endif
   }
   return self;
 }


### PR DESCRIPTION
In some old projects we use ghunit and we compile with an old SDK (iOS6)
This change make the branch compilable even with ancient iOS6 as the base SDK.

For reference:
SDK Compatibility Guide - Conditionally Compiling for Different SDKs
https://developer.apple.com/library/ios/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html
